### PR TITLE
feat: add SQLite database schema with migrations

### DIFF
--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -1,1 +1,392 @@
-export {};
+import { Database as SQLiteDatabase } from "bun:sqlite";
+import type { Profile, Session, Quota, UsageLog } from "../types/index.js";
+
+const SCHEMA_VERSION = 1;
+
+const CREATE_TABLES = `
+CREATE TABLE IF NOT EXISTS profiles (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  token_encrypted TEXT NOT NULL DEFAULT '',
+  base_url TEXT,
+  auth_method TEXT NOT NULL DEFAULT 'manual',
+  created_at INTEGER NOT NULL,
+  last_used INTEGER NOT NULL DEFAULT 0,
+  use_count INTEGER NOT NULL DEFAULT 0,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  tags TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  profile_id TEXT,
+  terminal TEXT NOT NULL,
+  started_at INTEGER NOT NULL,
+  last_activity INTEGER NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS quotas (
+  profile_id TEXT PRIMARY KEY,
+  daily_limit INTEGER,
+  monthly_limit INTEGER,
+  current_daily INTEGER NOT NULL DEFAULT 0,
+  current_monthly INTEGER NOT NULL DEFAULT 0,
+  last_reset_daily INTEGER NOT NULL,
+  last_reset_monthly INTEGER NOT NULL,
+  FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS usage_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  profile_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  tokens_used INTEGER NOT NULL,
+  model TEXT NOT NULL,
+  FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_profile ON sessions(profile_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_terminal ON sessions(terminal);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity DESC);
+CREATE INDEX IF NOT EXISTS idx_usage_log_session ON usage_log(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_log_profile ON usage_log(profile_id);
+CREATE INDEX IF NOT EXISTS idx_usage_log_timestamp ON usage_log(timestamp DESC);
+`;
+
+function getDbPath(): string {
+  const home = Bun.env.HOME ?? "/tmp";
+  return `${home}/.config/ccs/data.db`;
+}
+
+export class Database {
+  private db: SQLiteDatabase;
+  private static instance: Database | null = null;
+
+  private constructor(db: SQLiteDatabase) {
+    this.db = db;
+  }
+
+  static async initialize(): Promise<Database> {
+    if (Database.instance) {
+      return Database.instance;
+    }
+
+    const dbPath = getDbPath();
+
+    const db = new SQLiteDatabase(dbPath);
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA foreign_keys = ON");
+
+    const instance = new Database(db);
+    instance.runMigrations();
+
+    Database.instance = instance;
+    return instance;
+  }
+
+  static getInstance(): Database {
+    if (!Database.instance) {
+      throw new Error("Database not initialized. Call initialize() first.");
+    }
+    return Database.instance;
+  }
+
+  static async close(): Promise<void> {
+    if (Database.instance) {
+      Database.instance.db.close();
+      Database.instance = null;
+    }
+  }
+
+  private runMigrations(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY
+      );
+    `);
+
+    const result = this.db.query("SELECT version FROM schema_version LIMIT 1").get();
+    const currentVersion = (result as { version: number } | undefined)?.version ?? 0;
+
+    if (currentVersion < SCHEMA_VERSION) {
+      this.db.exec(CREATE_TABLES);
+      this.db.exec("DELETE FROM schema_version");
+      this.db.exec("INSERT INTO schema_version (version) VALUES (?)", [SCHEMA_VERSION]);
+    }
+  }
+
+  // Profile operations
+  getAllProfiles(): Profile[] {
+    const rows = this.db.query("SELECT * FROM profiles ORDER BY last_used DESC").all();
+    return rows.map(this.rowToProfile);
+  }
+
+  getProfileById(id: string): Profile | null {
+    const row = this.db.query("SELECT * FROM profiles WHERE id = ?").get(id);
+    return row ? this.rowToProfile(row) : null;
+  }
+
+  createProfile(profile: Profile): void {
+    this.db.exec(
+      `INSERT INTO profiles (id, name, token_encrypted, base_url, auth_method, created_at, last_used, use_count, metadata, tags)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        profile.id,
+        profile.name,
+        profile.token_encrypted,
+        profile.base_url ?? null,
+        profile.auth_method,
+        profile.created_at,
+        profile.last_used,
+        profile.use_count,
+        JSON.stringify(profile.metadata),
+        JSON.stringify(profile.tags),
+      ],
+    );
+  }
+
+  updateProfile(id: string, updates: Partial<Profile>): void {
+    const profile = this.getProfileById(id);
+    if (!profile) return;
+
+    const updated = { ...profile, ...updates };
+    this.db.exec(
+      `UPDATE profiles SET name = ?, token_encrypted = ?, base_url = ?, auth_method = ?,
+       last_used = ?, use_count = ?, metadata = ?, tags = ? WHERE id = ?`,
+      [
+        updated.name,
+        updated.token_encrypted,
+        updated.base_url ?? null,
+        updated.auth_method,
+        updated.last_used,
+        updated.use_count,
+        JSON.stringify(updated.metadata),
+        JSON.stringify(updated.tags),
+        id,
+      ],
+    );
+  }
+
+  deleteProfile(id: string): void {
+    this.db.exec("DELETE FROM profiles WHERE id = ?", [id]);
+  }
+
+  private rowToProfile(row: unknown): Profile {
+    const r = row as Record<string, unknown>;
+    return {
+      id: r.id as string,
+      name: r.name as string,
+      token_encrypted: r.token_encrypted as string,
+      base_url: (r.base_url as string) ?? undefined,
+      auth_method: r.auth_method as Profile["auth_method"],
+      created_at: r.created_at as number,
+      last_used: r.last_used as number,
+      use_count: r.use_count as number,
+      metadata: JSON.parse(r.metadata as string),
+      tags: JSON.parse(r.tags as string),
+    };
+  }
+
+  // Session operations
+  getAllSessions(): Session[] {
+    const rows = this.db.query("SELECT * FROM sessions ORDER BY last_activity DESC").all();
+    return rows.map(this.rowToSession);
+  }
+
+  getSessionById(id: string): Session | null {
+    const row = this.db.query("SELECT * FROM sessions WHERE id = ?").get(id);
+    return row ? this.rowToSession(row) : null;
+  }
+
+  getSessionByTerminal(terminal: string): Session | null {
+    const row = this.db.query("SELECT * FROM sessions WHERE terminal = ?").get(terminal);
+    return row ? this.rowToSession(row) : null;
+  }
+
+  createSession(session: Session): void {
+    this.db.exec(
+      `INSERT INTO sessions (id, profile_id, terminal, started_at, last_activity, metadata)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        session.id,
+        session.profile_id,
+        session.terminal,
+        session.started_at,
+        session.last_activity,
+        JSON.stringify(session.metadata),
+      ],
+    );
+  }
+
+  updateSession(id: string, updates: Partial<Session>): void {
+    const session = this.getSessionById(id);
+    if (!session) return;
+
+    const updated = { ...session, ...updates };
+    this.db.exec(
+      `UPDATE sessions SET profile_id = ?, terminal = ?, last_activity = ?, metadata = ? WHERE id = ?`,
+      [
+        updated.profile_id,
+        updated.terminal,
+        updated.last_activity,
+        JSON.stringify(updated.metadata),
+        id,
+      ],
+    );
+  }
+
+  deleteSession(id: string): void {
+    this.db.exec("DELETE FROM sessions WHERE id = ?", [id]);
+  }
+
+  deleteStaleSessions(maxAgeMs: number): void {
+    const cutoff = Date.now() - maxAgeMs;
+    this.db.exec("DELETE FROM sessions WHERE last_activity < ?", [cutoff]);
+  }
+
+  private rowToSession(row: unknown): Session {
+    const r = row as Record<string, unknown>;
+    return {
+      id: r.id as string,
+      profile_id: r.profile_id as string | null,
+      terminal: r.terminal as string,
+      started_at: r.started_at as number,
+      last_activity: r.last_activity as number,
+      metadata: JSON.parse(r.metadata as string),
+    };
+  }
+
+  // Quota operations
+  getQuota(profileId: string): Quota | null {
+    const row = this.db.query("SELECT * FROM quotas WHERE profile_id = ?").get(profileId);
+    return row ? this.rowToQuota(row) : null;
+  }
+
+  createOrUpdateQuota(quota: Quota): void {
+    this.db.exec(
+      `INSERT INTO quotas (profile_id, daily_limit, monthly_limit, current_daily, current_monthly, last_reset_daily, last_reset_monthly)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(profile_id) DO UPDATE SET
+         daily_limit = excluded.daily_limit,
+         monthly_limit = excluded.monthly_limit,
+         current_daily = excluded.current_daily,
+         current_monthly = excluded.current_monthly,
+         last_reset_daily = excluded.last_reset_daily,
+         last_reset_monthly = excluded.last_reset_monthly`,
+      [
+        quota.profile_id,
+        quota.daily_limit,
+        quota.monthly_limit,
+        quota.current_daily,
+        quota.current_monthly,
+        quota.last_reset_daily,
+        quota.last_reset_monthly,
+      ],
+    );
+  }
+
+  updateQuotaCounters(profileId: string, dailyTokens: number, monthlyTokens: number): void {
+    const quota = this.getQuota(profileId);
+    if (!quota) return;
+
+    this.db.exec(`UPDATE quotas SET current_daily = ?, current_monthly = ? WHERE profile_id = ?`, [
+      quota.current_daily + dailyTokens,
+      quota.current_monthly + monthlyTokens,
+      profileId,
+    ]);
+  }
+
+  resetQuotaCounters(profileId: string): void {
+    const now = Date.now();
+    this.db.exec(
+      `UPDATE quotas SET current_daily = 0, current_monthly = 0, last_reset_daily = ?, last_reset_monthly = ? WHERE profile_id = ?`,
+      [now, now, profileId],
+    );
+  }
+
+  private rowToQuota(row: unknown): Quota {
+    const r = row as Record<string, unknown>;
+    return {
+      profile_id: r.profile_id as string,
+      daily_limit: r.daily_limit as number | null,
+      monthly_limit: r.monthly_limit as number | null,
+      current_daily: r.current_daily as number,
+      current_monthly: r.current_monthly as number,
+      last_reset_daily: r.last_reset_daily as number,
+      last_reset_monthly: r.last_reset_monthly as number,
+    };
+  }
+
+  // Usage log operations
+  logUsage(log: Omit<UsageLog, "id">): void {
+    this.db.exec(
+      `INSERT INTO usage_log (profile_id, session_id, timestamp, tokens_used, model) VALUES (?, ?, ?, ?, ?)`,
+      [log.profile_id, log.session_id, log.timestamp, log.tokens_used, log.model],
+    );
+  }
+
+  getUsageLogs(profileId: string, limit = 100): UsageLog[] {
+    const rows = this.db
+      .query("SELECT * FROM usage_log WHERE profile_id = ? ORDER BY timestamp DESC LIMIT ?")
+      .all(profileId, limit);
+    return rows.map(this.rowToUsageLog);
+  }
+
+  getUsageBySession(sessionId: string): UsageLog[] {
+    const rows = this.db
+      .query("SELECT * FROM usage_log WHERE session_id = ? ORDER BY timestamp DESC")
+      .all(sessionId);
+    return rows.map(this.rowToUsageLog);
+  }
+
+  private rowToUsageLog(row: unknown): UsageLog {
+    const r = row as Record<string, unknown>;
+    return {
+      id: r.id as number,
+      profile_id: r.profile_id as string,
+      session_id: r.session_id as string,
+      timestamp: r.timestamp as number,
+      tokens_used: r.tokens_used as number,
+      model: r.model as string,
+    };
+  }
+
+  // Settings operations
+  getSetting<T>(key: string): T | null {
+    const row = this.db.query("SELECT value FROM settings WHERE key = ?").get(key);
+    if (!row) return null;
+    return JSON.parse((row as { value: string }).value) as T;
+  }
+
+  setSetting<T>(key: string, value: T): void {
+    this.db.exec(
+      "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      [key, JSON.stringify(value)],
+    );
+  }
+
+  deleteSetting(key: string): void {
+    this.db.exec("DELETE FROM settings WHERE key = ?", [key]);
+  }
+}
+
+export async function initializeDatabase(): Promise<Database> {
+  return Database.initialize();
+}
+
+export async function closeDatabase(): Promise<void> {
+  return Database.close();
+}
+
+export function getDatabase(): Database {
+  return Database.getInstance();
+}

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  Database,
+  closeDatabase,
+} from "../../src/core/storage";
+
+let db: Database;
+
+async function createTestDb(): Promise<Database> {
+  const testDbPath = `/tmp/ccs-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
+  const db = new Database(
+    new (await import("bun:sqlite")).Database(testDbPath) as never,
+  );
+  db.runMigrations();
+  return db;
+}
+
+describe("Database", () => {
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  describe("Profile operations", () => {
+    test("create and get profile", () => {
+      const now = Date.now();
+      db.createProfile({
+        id: "test@example.com",
+        name: "Test Profile",
+        token_encrypted: "encrypted-token",
+        auth_method: "manual",
+        created_at: now,
+        last_used: now,
+        use_count: 0,
+        metadata: {},
+        tags: ["test"],
+      });
+
+      const profile = db.getProfileById("test@example.com");
+      expect(profile).not.toBeNull();
+      expect(profile?.name).toBe("Test Profile");
+      expect(profile?.auth_method).toBe("manual");
+      expect(profile?.tags).toEqual(["test"]);
+    });
+
+    test("get all profiles", () => {
+      const now = Date.now();
+      db.createProfile({
+        id: "profile1@example.com",
+        name: "Profile 1",
+        token_encrypted: "token1",
+        auth_method: "manual",
+        created_at: now,
+        last_used: now,
+        use_count: 0,
+        metadata: {},
+        tags: [],
+      });
+      db.createProfile({
+        id: "profile2@example.com",
+        name: "Profile 2",
+        token_encrypted: "token2",
+        auth_method: "oauth",
+        created_at: now,
+        last_used: now,
+        use_count: 0,
+        metadata: {},
+        tags: [],
+      });
+
+      const profiles = db.getAllProfiles();
+      expect(profiles).toHaveLength(2);
+    });
+
+    test("update profile", () => {
+      const now = Date.now();
+      db.createProfile({
+        id: "test@example.com",
+        name: "Original Name",
+        token_encrypted: "token",
+        auth_method: "manual",
+        created_at: now,
+        last_used: now,
+        use_count: 0,
+        metadata: {},
+        tags: [],
+      });
+
+      db.updateProfile("test@example.com", {
+        name: "Updated Name",
+        use_count: 5,
+      });
+      const profile = db.getProfileById("test@example.com");
+      expect(profile?.name).toBe("Updated Name");
+      expect(profile?.use_count).toBe(5);
+    });
+
+    test("delete profile", () => {
+      const now = Date.now();
+      db.createProfile({
+        id: "test@example.com",
+        name: "Test",
+        token_encrypted: "token",
+        auth_method: "manual",
+        created_at: now,
+        last_used: now,
+        use_count: 0,
+        metadata: {},
+        tags: [],
+      });
+
+      db.deleteProfile("test@example.com");
+      expect(db.getProfileById("test@example.com")).toBeNull();
+    });
+  });
+
+  describe("Session operations", () => {
+    test("create and get session", () => {
+      const now = Date.now();
+      db.createSession({
+        id: "session-1",
+        profile_id: null,
+        terminal: "/dev/tty1",
+        started_at: now,
+        last_activity: now,
+        metadata: { shell: "bash", cwd: "/home", parent_pid: 1234 },
+      });
+
+      const session = db.getSessionById("session-1");
+      expect(session).not.toBeNull();
+      expect(session?.terminal).toBe("/dev/tty1");
+    });
+
+    test("get session by terminal", () => {
+      const now = Date.now();
+      db.createSession({
+        id: "session-1",
+        profile_id: null,
+        terminal: "/dev/tty1",
+        started_at: now,
+        last_activity: now,
+        metadata: { shell: "bash", cwd: "/home", parent_pid: 1234 },
+      });
+
+      const session = db.getSessionByTerminal("/dev/tty1");
+      expect(session?.id).toBe("session-1");
+    });
+
+    test("delete stale sessions", () => {
+      const now = Date.now();
+      db.createSession({
+        id: "old-session",
+        profile_id: null,
+        terminal: "/dev/tty1",
+        started_at: now - 100000,
+        last_activity: now - 100000,
+        metadata: { shell: "bash", cwd: "/home", parent_pid: 1234 },
+      });
+
+      db.deleteStaleSessions(60000);
+      expect(db.getAllSessions()).toHaveLength(0);
+    });
+  });
+
+  describe("Quota operations", () => {
+    test("create and get quota", () => {
+      const now = Date.now();
+      db.createOrUpdateQuota({
+        profile_id: "test@example.com",
+        daily_limit: 5000,
+        monthly_limit: 100000,
+        current_daily: 0,
+        current_monthly: 0,
+        last_reset_daily: now,
+        last_reset_monthly: now,
+      });
+
+      const quota = db.getQuota("test@example.com");
+      expect(quota?.daily_limit).toBe(5000);
+      expect(quota?.monthly_limit).toBe(100000);
+    });
+
+    test("update quota counters", () => {
+      const now = Date.now();
+      db.createOrUpdateQuota({
+        profile_id: "test@example.com",
+        daily_limit: 5000,
+        monthly_limit: 100000,
+        current_daily: 100,
+        current_monthly: 500,
+        last_reset_daily: now,
+        last_reset_monthly: now,
+      });
+
+      db.updateQuotaCounters("test@example.com", 50, 200);
+      const quota = db.getQuota("test@example.com");
+      expect(quota?.current_daily).toBe(150);
+      expect(quota?.current_monthly).toBe(700);
+    });
+  });
+
+  describe("Usage log operations", () => {
+    test("log and retrieve usage", () => {
+      const now = Date.now();
+      db.logUsage({
+        profile_id: "test@example.com",
+        session_id: "session-1",
+        timestamp: now,
+        tokens_used: 1000,
+        model: "claude-3-sonnet",
+      });
+
+      const logs = db.getUsageLogs("test@example.com");
+      expect(logs).toHaveLength(1);
+      expect(logs[0]?.tokens_used).toBe(1000);
+      expect(logs[0]?.model).toBe("claude-3-sonnet");
+    });
+  });
+
+  describe("Settings operations", () => {
+    test("set and get setting", () => {
+      db.setSetting("theme", "dark");
+      expect(db.getSetting<string>("theme")).toBe("dark");
+    });
+
+    test("get non-existent setting returns null", () => {
+      expect(db.getSetting("nonexistent")).toBeNull();
+    });
+
+    test("delete setting", () => {
+      db.setSetting("temp", "value");
+      db.deleteSetting("temp");
+      expect(db.getSetting("temp")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add SQLite database schema with migrations using Bun's native `bun:sqlite`
- Implement `Database` class with singleton pattern
- Tables: `profiles`, `sessions`, `quotas`, `usage_log`, `settings`
- Full CRUD operations for all entities
- Migration system with version tracking
- Unit tests for all database operations

## Linked Issue
Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced persistent storage system for user profiles, sessions, and application data with automatic data management.
  * Implemented usage quota and consumption tracking capabilities with counter management and reset functionality.
  * Added configuration storage for application settings and preferences.

* **Tests**
  * Added comprehensive test suite validating storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->